### PR TITLE
Remove deprecated form of constructor

### DIFF
--- a/Mobilpay/Payment/Request.php
+++ b/Mobilpay/Payment/Request.php
@@ -91,7 +91,7 @@ class Mobilpay_Payment_Request
 	 */
 	public $m_params		= array();
 	
-	function Mobilpay_Payment_Request()
+	function __construct()
 	{
 		
 	}


### PR DESCRIPTION
PHP 4 style constructors (methods that have the same name as the class they are defined in) are deprecated, and will be removed in the future. PHP 7 will emit E_DEPRECATED if a PHP 4 constructor is the only constructor defined within a class.

See http://php.net/manual/en/migration70.deprecated.php